### PR TITLE
Create 'dialogs' table during initialization of a database from scratch

### DIFF
--- a/qml/js/storage.js
+++ b/qml/js/storage.js
@@ -53,6 +53,7 @@ function initDatabase() {
                                                             'first_name TEXT, ' +
                                                             'last_name  TEXT, ' +
                                                             'avatar     TEXT)')
+            tx.executeSql('CREATE TABLE IF NOT EXISTS dialogs (id INTEGER UNIQUE, title TEXT)')
         })
     } else if (db.version !== DATABASE_VERSION) {
         if (db.version === '3') db.transaction( function (tx) {


### PR DESCRIPTION
When installing the latest version on a device, where harbour-kat was not installed previously, I faced a problem: the Messages view was stuck in loading (after choosing the update option in the pulley menu) indefinitely. The following was appearing in the logs: 

```
[W] unknown:313 - file:///usr/share/harbour-kat/qml/js/storage.js:313: Error: no such table: dialogs Unable to execute statement.
```

The problem occured due to the fact that in latest version, the dialogs table is not created for a new database, only during updating an old one, which is resolved by this commit.
